### PR TITLE
ci: add test workflow and document workflow naming convention

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,41 @@
+name: Test
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/**'
+      - 'package.json'
+      - 'bun.lock'
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'package.json'
+      - 'bun.lock'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run tests
+        run: bun run test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,11 @@ bun run src/cli.ts
 - **新しい PR は最新 main から**: 新しいブランチは必ず `git fetch origin main && git checkout -b <branch> origin/main` で作成する。他の PR のコミットが混入しないようにする。
 - **force push**: rebase 後は `git push --force-with-lease` を使う。
 
+## GitHub Actions ワークフロー命名規則
+
+- **`_` プレフィックス付き** (`_actionlint.yaml`, `_secretlint.yaml` 等): 他プロジェクトでも共通で使う汎用ワークフロー。
+- **`_` プレフィックスなし** (`test.yaml` 等): このプロジェクト固有のワークフロー。
+
 ## 重要なパターン
 
 - **ESM only**: `"type": "module"`。import には `.js` 拡張子を付ける (`import { foo } from "./foo.js"`)。Node 組み込みは `node:` プレフィックス。


### PR DESCRIPTION
## 概要
- `vitest run` を実行するテスト用 GitHub Actions ワークフロー (`test.yaml`) を追加
- CLAUDE.md にワークフロー命名規則（`_` プレフィックスの意味）を追記

## テストプラン
- [ ] PR 作成時にテストワークフローが正常に実行されること
- [ ] `bun run test` が全パスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)