### PR TITLE
refactor: replace softprops/action-gh-release with gh CLI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,13 +63,6 @@ jobs:
           cp src/logo/logo-color.ascii dist/logo-color.ascii
 
       - name: Upload release assets
-        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
-        with:
-          tag_name: ${{ needs.release-please.outputs.tag_name }}
-          files: |
-            dist/pm-darwin-x64
-            dist/pm-darwin-arm64
-            dist/pm-linux-x64
-            dist/pm-linux-arm64
-            dist/pm.zsh
-            dist/logo-color.ascii
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ needs.release-please.outputs.tag_name }}" dist/*


### PR DESCRIPTION
## 概要

- リリースアセットのアップロードを `softprops/action-gh-release` から `gh release upload` (GitHub 公式 CLI) に置き換え
- サードパーティ Action への依存を削除

## 変更理由

- GitHub 公式 CLI でサプライチェーンリスクをゼロに
- このプロジェクトの「外部依存なし」の方針と整合
- 機能的に同等（既存リリースへのファイルアップロードのみ）

## テストプラン

- [ ] Release PR マージ後にバイナリが GitHub Release にアップロードされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)