### PR TITLE
fix: use PATH export as shell config marker instead of comment

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -80,7 +80,8 @@ download() {
 # ---------------------------------------------------------------------------
 configure_shell() {
   local zshrc="$HOME/.zshrc"
-  local marker="# pm (project)"
+  # shellcheck disable=SC2016
+  local marker='export PATH="$HOME/.pm/bin:$PATH"'
 
   # Skip if already configured
   if [ -f "$zshrc" ] && grep -qF "$marker" "$zshrc"; then
@@ -91,7 +92,7 @@ configure_shell() {
   local config_block
   config_block=$(cat <<'BLOCK'
 
-# pm (project)
+# pm - VS Code Project Manager CLI
 export PATH="$HOME/.pm/bin:$PATH"
 source "$HOME/.pm/pm.zsh"
 BLOCK


### PR DESCRIPTION
## 概要

- `.zshrc` の重複追記を防ぐマーカーをコメント (`# pm (project)`) から `export PATH` 行に変更
  - コメントはユーザーが整理時に削除する可能性があるため、実際の設定行をマーカーにすることで確実に検出
- `.zshrc` に追記されるコメントを `# pm - VS Code Project Manager CLI` に更新

## テストプラン

- [ ] 新規インストール時に `.zshrc` に正しく設定が追記されることを確認
- [ ] 再インストール時に設定が重複追記されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)