### PR TITLE
refactor: migrate install paths to XDG Base Directory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,30 @@ bun dev logo
 - **`scripts/demo.sh`**: Linux バイナリのクロスコンパイル → Docker ビルド → 全テープ実行を自動化。
 - VHS はシェル起動時にプロンプト (PS1/PROMPT) をハードコードで上書きするため、Dockerfile や `Env` コマンドではプロンプトを変更できない。`Hide` + `clear` が現時点での唯一の回避策。参照: [vhs#419](https://github.com/charmbracelet/vhs/issues/419), [vhs#130](https://github.com/charmbracelet/vhs/issues/130)
 
+## インストール・配布設計
+
+### XDG Base Directory 準拠
+
+ユーザー環境へのファイル配置は XDG Base Directory に従う。
+
+| 種類 | パス | 環境変数 |
+|------|------|---------|
+| バイナリ | `~/.local/bin/pm` | `XDG_BIN_HOME` |
+| シェルラッパー・設定 | `~/.config/pm/` | `XDG_CONFIG_HOME` |
+
+### ビルド・配布チャネル
+
+| チャネル | ビルドコマンド | 備考 |
+|---------|-------------|------|
+| バイナリ (curl \| bash) | `bun run build` | Bun クロスコンパイル。CI で 4 プラットフォーム分ビルド |
+| npm | `prepublishOnly` に記述 | `npm publish` 時に自動実行 |
+| Homebrew | CI ワークフローで対応 | package.json には含めない |
+
+### install.sh の設計ルール
+
+- `.zshrc` への重複追記防止には `source` 行をマーカーとして使う（コメントはユーザーに削除される可能性がある）
+- XDG 環境変数のフォールバックは常に記述する: `${XDG_CONFIG_HOME:-$HOME/.config}`
+
 ## Git ワークフロー
 
 - **rebase 優先**: main の最新を取り込む際は `git merge` ではなく `git rebase origin/main` を使う。マージコミットでの履歴汚染を避ける。

--- a/install.sh
+++ b/install.sh
@@ -4,8 +4,8 @@
 set -euo pipefail
 
 REPO="nozomiishii/pm"
-INSTALL_DIR="$HOME/.pm"
-BIN_DIR="$INSTALL_DIR/bin"
+BIN_DIR="${XDG_BIN_HOME:-$HOME/.local/bin}"
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/pm"
 
 # ---------------------------------------------------------------------------
 # Detect platform
@@ -52,21 +52,20 @@ download() {
 
   local binary_url="${base_url}/pm-${platform}"
   local zsh_url="${base_url}/pm.zsh"
-
   local logo_url="${base_url}/logo-color.ascii"
 
-  mkdir -p "$BIN_DIR"
+  mkdir -p "$BIN_DIR" "$CONFIG_DIR"
 
   echo "Downloading pm for ${platform}..."
 
   if command -v curl >/dev/null; then
     curl -fsSL "$binary_url" -o "$BIN_DIR/pm"
-    curl -fsSL "$zsh_url" -o "$INSTALL_DIR/pm.zsh"
-    curl -fsSL "$logo_url" -o "$INSTALL_DIR/logo-color.ascii" 2>/dev/null || true
+    curl -fsSL "$zsh_url" -o "$CONFIG_DIR/pm.zsh"
+    curl -fsSL "$logo_url" -o "$CONFIG_DIR/logo-color.ascii" 2>/dev/null || true
   elif command -v wget >/dev/null; then
     wget -qO "$BIN_DIR/pm" "$binary_url"
-    wget -qO "$INSTALL_DIR/pm.zsh" "$zsh_url"
-    wget -qO "$INSTALL_DIR/logo-color.ascii" "$logo_url" 2>/dev/null || true
+    wget -qO "$CONFIG_DIR/pm.zsh" "$zsh_url"
+    wget -qO "$CONFIG_DIR/logo-color.ascii" "$logo_url" 2>/dev/null || true
   else
     echo "Error: curl or wget is required" >&2
     exit 1
@@ -81,7 +80,7 @@ download() {
 configure_shell() {
   local zshrc="$HOME/.zshrc"
   # shellcheck disable=SC2016
-  local marker='export PATH="$HOME/.pm/bin:$PATH"'
+  local marker='source "${XDG_CONFIG_HOME:-$HOME/.config}/pm/pm.zsh"'
 
   # Skip if already configured
   if [ -f "$zshrc" ] && grep -qF "$marker" "$zshrc"; then
@@ -93,8 +92,8 @@ configure_shell() {
   config_block=$(cat <<'BLOCK'
 
 # pm - VS Code Project Manager CLI
-export PATH="$HOME/.pm/bin:$PATH"
-source "$HOME/.pm/pm.zsh"
+export PATH="${XDG_BIN_HOME:-$HOME/.local/bin}:$PATH"
+source "${XDG_CONFIG_HOME:-$HOME/.config}/pm/pm.zsh"
 BLOCK
 )
 
@@ -121,15 +120,15 @@ main() {
   echo "You love VS Code Project Manager? So do I! Now it's in your terminal too."
   echo ""
 
-  if [ -f "$INSTALL_DIR/logo-color.ascii" ]; then
-    cat "$INSTALL_DIR/logo-color.ascii"
-    rm -f "$INSTALL_DIR/logo-color.ascii"
+  if [ -f "$CONFIG_DIR/logo-color.ascii" ]; then
+    cat "$CONFIG_DIR/logo-color.ascii"
+    rm -f "$CONFIG_DIR/logo-color.ascii"
   fi
 
   echo ""
   echo "pm was installed successfully!"
   echo "  Binary:  $BIN_DIR/pm"
-  echo "  Shell:   $INSTALL_DIR/pm.zsh"
+  echo "  Shell:   $CONFIG_DIR/pm.zsh"
   echo ""
   echo "Restart your terminal or run:"
   echo "  source ~/.zshrc"


### PR DESCRIPTION
## 概要

インストール先を XDG Base Directory 準拠に移行。

| 種類 | 変更前 | 変更後 |
|------|--------|--------|
| バイナリ | `~/.pm/bin/pm` | `~/.local/bin/pm` (`XDG_BIN_HOME`) |
| シェルラッパー | `~/.pm/pm.zsh` | `~/.config/pm/pm.zsh` (`XDG_CONFIG_HOME`) |

- starship 等の主要ツールが XDG 準拠に移行する流れに合わせた対応
- XDG 環境変数をカスタマイズしている場合はそちらに従う
- `.zshrc` の重複追記防止マーカーを `source` 行に変更
- CLAUDE.md にインストール・配布設計セクションを追加

## テストプラン

- [ ] `curl | bash` でインストールして `~/.local/bin/pm` と `~/.config/pm/pm.zsh` に配置されることを確認
- [ ] `source ~/.zshrc` 後に `pm` コマンドが動作することを確認
- [ ] 再インストールで設定が重複追記されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)