### PR TITLE
feat: add npm publish support

### DIFF
--- a/.github/.release-please-config.json
+++ b/.github/.release-please-config.json
@@ -5,7 +5,7 @@
   "bump-patch-for-minor-pre-major": true,
   "packages": {
     ".": {
-      "release-type": "simple"
+      "release-type": "node"
     }
   }
 }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,14 +9,15 @@ defaults:
   run:
     shell: bash
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   release-please:
     runs-on: ubuntu-slim
     timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
 
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
@@ -35,6 +36,8 @@ jobs:
     if: needs.release-please.outputs.release_created == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout code
@@ -66,3 +69,42 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh release upload "${{ needs.release-please.outputs.tag_name }}" dist/*
+
+  npm-publish:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version-file: package.json
+          registry-url: https://registry.npmjs.org
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Type check
+        run: bun run typecheck
+
+      - name: Run tests
+        run: bun run test
+
+      - name: Build for npm
+        run: bun run build:npm
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,11 +7,13 @@ on:
     paths:
       - 'src/**'
       - 'package.json'
+      - 'tsconfig.json'
       - 'bun.lock'
   pull_request:
     paths:
       - 'src/**'
       - 'package.json'
+      - 'tsconfig.json'
       - 'bun.lock'
 
 concurrency:
@@ -36,6 +38,9 @@ jobs:
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
+
+      - name: Type check
+        run: bun run typecheck
 
       - name: Run tests
         run: bun run test

--- a/README.ja.md
+++ b/README.ja.md
@@ -32,6 +32,8 @@ sudo pacman -S fzf
 
 ## Install
 
+### Shell script (推奨)
+
 ```sh
 curl -fsSL https://raw.githubusercontent.com/nozomiishii/pm/main/install.sh | bash
 ```
@@ -39,6 +41,12 @@ curl -fsSL https://raw.githubusercontent.com/nozomiishii/pm/main/install.sh | ba
 `pm`のバイナリが `~/.pm/bin/pm` にダウンロードされ、`pm`を呼び出すラッパースクリプトが `~/.pm/pm.zsh` に配置されます。`.zshrc` への設定も自動で追加されます。
 
 ターミナルを再起動するか、`source ~/.zshrc` を実行すると`pm`が使えるようになります。
+
+### npm
+
+```sh
+npm install -g @nozomiishii/pm
+```
 
 ## Uninstall
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ sudo pacman -S fzf
 
 ## Install
 
+### Shell script (recommended)
+
 ```sh
 curl -fsSL https://raw.githubusercontent.com/nozomiishii/pm/main/install.sh | bash
 ```
@@ -39,6 +41,12 @@ curl -fsSL https://raw.githubusercontent.com/nozomiishii/pm/main/install.sh | ba
 The `pm` binary is downloaded to `~/.pm/bin/pm`, and the wrapper script that calls `pm` is placed at `~/.pm/pm.zsh`. The `.zshrc` configuration is added automatically.
 
 Restart your terminal or run `source ~/.zshrc` to start using pm.
+
+### npm
+
+```sh
+npm install -g @nozomiishii/pm
+```
 
 ## Uninstall
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nozomiishii/pm",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Project manager CLI — jump to projects via fzf",
   "type": "module",
   "homepage": "https://github.com/nozomiishii/pm#readme",
@@ -14,10 +14,17 @@
   "license": "MIT",
   "author": "Nozomi Ishii",
   "bin": {
-    "pm": "./src/cli.ts"
+    "pm": "./dist/cli.js"
   },
+  "files": [
+    "dist/cli.js",
+    "src/pm.zsh"
+  ],
   "scripts": {
     "build": "bun build --compile src/cli.ts --outfile dist/pm",
+    "build:npm": "bun build src/cli.ts --outfile dist/cli.js --target=node && bun -e \"await Bun.write('dist/cli.js', (await Bun.file('dist/cli.js').text()).replace('#!/usr/bin/env bun\\n// @bun\\n', '#!/usr/bin/env node\\n'))\"",
+    "prepublishOnly": "bun run build:npm",
+    "typecheck": "tsc --noEmit",
     "dev": "bun run src/cli.ts",
     "demo": "docker run --rm -v \"$(pwd)\":/vhs pm-vhs",
     "demo:all": "bash demo/create.sh",


### PR DESCRIPTION
closes #19

## 概要

`npm install -g @nozomiishii/pm` で pm をインストールできるようにする。

## 変更内容

- **package.json**: `bin` を `dist/cli.js` に変更、`files`・`build:npm`・`prepublishOnly`・`typecheck` スクリプト追加、version を 0.1.2 に同期
- **release-please**: `release-type` を `simple` → `node` に変更（package.json の version 自動更新）
- **test.yaml**: `tsc --noEmit` 型チェックステップ追加、`tsconfig.json` を paths トリガーに追加
- **release.yaml**: `npm-publish` ジョブ追加（`--provenance --access public`）、permissions をジョブレベルに最小化
- **README**: npm インストール方法を追記（日英両方）

## npm ビルド方式

`bun build src/cli.ts --outfile dist/cli.js --target=node` で TypeScript を単一の Node.js 互換 JS にバンドル。Bun 固有の `import ... with { type: "text" }` もインライン化され、シバンも `#!/usr/bin/env node` に置換される。

## npm publish 前に必要な手動作業

- GitHub リポジトリに `NPM_TOKEN` シークレットを設定

## テスト

- [x] `bun run typecheck` — 型チェック通過
- [x] `bun run test` — 全288テスト通過
- [x] `bun run build:npm` — `dist/cli.js` 生成、シバン `#!/usr/bin/env node`
- [x] `node dist/cli.js --help` — Node.js で正常動作
- [x] `node dist/cli.js logo` — テキスト import のインライン化確認
- [x] `npm pack --dry-run` — 6ファイル、7.8KB