### PR TITLE
fix: simplify release-please PR title

### DIFF
--- a/.github/.release-please-config.json
+++ b/.github/.release-please-config.json
@@ -5,7 +5,9 @@
   "bump-patch-for-minor-pre-major": true,
   "packages": {
     ".": {
-      "release-type": "node"
+      "release-type": "node",
+      "component": "",
+      "pull-request-title-pattern": "chore: release ${version}"
     }
   }
 }


### PR DESCRIPTION
## 概要

release-please のリリース PR タイトルからコンポーネント名とスコープを削除し、シンプルにする。

## 背景

`release-type` を `simple` → `node` に変更した際、release-please が `package.json` の `name`（`@nozomiishii/pm`）からコンポーネント名を自動取得するようになり、PR タイトルが `chore(main): release pm 0.1.3` になった。単一パッケージのリポジトリなのでコンポーネント名もスコープも不要。

## 変更内容

- `"component": ""` — コンポーネント名を空にする
- `"pull-request-title-pattern": "chore: release ${version}"` — `chore: release 0.1.3` のようなシンプルなタイトルにする