### PR TITLE
fix: remove component prefix from release tags

### DIFF
--- a/.github/.release-please-config.json
+++ b/.github/.release-please-config.json
@@ -3,11 +3,11 @@
   "bootstrap-sha": "3f1baf7e59a59712e147b360c40a54d04c43287a",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
+  "include-component-in-tag": false,
+  "pull-request-title-pattern": "chore: release ${version}",
   "packages": {
     ".": {
-      "release-type": "node",
-      "component": "",
-      "pull-request-title-pattern": "chore: release ${version}"
+      "release-type": "node"
     }
   }
 }


### PR DESCRIPTION
## 概要

リリースタグとタイトルからコンポーネントプレフィックスを除去し、`v0.1.3` のようなシンプルな形式にする。

## 変更内容

- `include-component-in-tag: false` をトップレベルに追加 — タグが `pm-v0.1.3` → `v0.1.3` になる
- `pull-request-title-pattern` をトップレベルに移動 — 将来のモノレポ化時にも全パッケージ共通で適用される
- 不要になった `component: ""` を削除