### PR TITLE
fix: add issues write permission to release-please workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: write
+      issues: write
       pull-requests: write
 
     outputs:


### PR DESCRIPTION
## Summary
release-please ワークフローに `issues: write` パーミッションを追加。

## 背景
GitHub のラベル API は Issues エンドポイントを使用するため、`issues: write` パーミッションが必要。[公式ドキュメント](https://github.com/googleapis/release-please-action#workflow-permissions)でも推奨されているが、現行ワークフローに含まれていなかった。

[nozomiishii/git-harvest](https://github.com/nozomiishii/git-harvest/actions/runs/23703808511) で同じ設定不足によりラベル付与の失敗が発生。

関連 Issue: [googleapis/release-please-action#1074](https://github.com/googleapis/release-please-action/issues/1074)

## 変更内容
- `release-please` ジョブのパーミッションに `issues: write` を追加

## Test plan
- [ ] 次回の release-please 実行でラベルが正常に付与されることを確認