### PR TITLE
fix: update shared CI workflows to v1.1.1 and add pull-requests read

### DIFF
--- a/.github/workflows/_actionlint.yaml
+++ b/.github/workflows/_actionlint.yaml
@@ -13,7 +13,8 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   actionlint:
-    uses: nozomiishii/workflows/.github/workflows/actionlint.yaml@ec605e0a4f2acdb21166f3b430dd9345dd4dca2b # v1.1.0
+    uses: nozomiishii/workflows/.github/workflows/actionlint.yaml@7e6fb98cc189a7b5ef23eee616a04238c5d9a468 # v1.1.1

--- a/.github/workflows/_pull-request.yaml
+++ b/.github/workflows/_pull-request.yaml
@@ -12,4 +12,4 @@ permissions:
 
 jobs:
   pull-request:
-    uses: nozomiishii/workflows/.github/workflows/pull-request.yaml@ec605e0a4f2acdb21166f3b430dd9345dd4dca2b # v1.1.0
+    uses: nozomiishii/workflows/.github/workflows/pull-request.yaml@7e6fb98cc189a7b5ef23eee616a04238c5d9a468 # v1.1.1

--- a/.github/workflows/_secretlint.yaml
+++ b/.github/workflows/_secretlint.yaml
@@ -12,4 +12,4 @@ permissions:
 
 jobs:
   secretlint:
-    uses: nozomiishii/workflows/.github/workflows/secretlint.yaml@ec605e0a4f2acdb21166f3b430dd9345dd4dca2b # v1.1.0
+    uses: nozomiishii/workflows/.github/workflows/secretlint.yaml@7e6fb98cc189a7b5ef23eee616a04238c5d9a468 # v1.1.1


### PR DESCRIPTION
v1.1.1 で actionlint reusable workflow に `pull-requests: read` が追加された。caller 側にも同権限を追加し、SHA を v1.1.1 に更新。