### PR TITLE
chore: serialize release workflow to avoid 1Password flakes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,10 @@ defaults:
   run:
     shell: bash
 
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 # デフォルト権限を無効化し、各ジョブで必要最小限の権限のみ付与する
 permissions: {}
 


### PR DESCRIPTION
## Summary

Release ワークフローに `concurrency` を追加し、直列実行を強制する。

## 背景

[run 24732884087](https://github.com/nozomiishii/pm/actions/runs/24732884087) で Release ワークフローの `Load secrets from 1Password` ステップが 401 Unauthorized で失敗した。前後のランは同一 secret で成功しているため、設定起因ではなく 1Password Service Account API 側の一時的な不整合と推測される。

```
Authenticated with Service account.   ← 認証は成功
Populating variable: APP_PRIVATE_KEY   ← credential 取得開始
##[error]could not read secret '.../credential':
  error initializing client: Authorization: (401) (Unauthorized)
```

Renovate PR 6 件が 5 分間に立て続けに merge された結果、Release ワークフローが 6 回並行実行されていた。このタイミングで 1 件だけ 401 が返っている。

## 変更内容

- `release.yaml` に `concurrency: { group: release, cancel-in-progress: false }` を追加
- トリガーは `push: main` と `workflow_dispatch` のみなので静的グループで十分
- release を途中キャンセルしたくないため `cancel-in-progress: false`

## Test plan

- [ ] merge 後、次の Renovate PR 連続 merge 時に Release ワークフローが直列実行されることを確認
