### PR TITLE
chore: migrate reusable workflows to v3.0.0

### DIFF
--- a/.github/workflows/_github-actions.yaml
+++ b/.github/workflows/_github-actions.yaml
@@ -12,9 +12,9 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
-  pull-requests: read
-  actions: read
+  contents: read  # required by actions/checkout to fetch repository code
+  pull-requests: read  # required by dorny/paths-filter to list PR files via the GitHub API
+  actions: read  # required by gh api referenced_workflows to resolve the zizmor config SHA
 
 jobs:
   github-actions:

--- a/.github/workflows/_github-actions.yaml
+++ b/.github/workflows/_github-actions.yaml
@@ -1,4 +1,4 @@
-name: Lint GitHub Actions workflows
+name: GitHub Actions
 
 on:
   workflow_dispatch:
@@ -14,7 +14,8 @@ concurrency:
 permissions:
   contents: read
   pull-requests: read
+  actions: read
 
 jobs:
-  actionlint:
-    uses: nozomiishii/workflows/.github/workflows/actionlint.yaml@7e6fb98cc189a7b5ef23eee616a04238c5d9a468 # v1.1.1
+  github-actions:
+    uses: nozomiishii/workflows/.github/workflows/github-actions.yaml@4114f39af968607bdcef88b48d29605df89728fd # v3.0.0

--- a/.github/workflows/_pull-request.yaml
+++ b/.github/workflows/_pull-request.yaml
@@ -8,7 +8,7 @@ on:
       - synchronize
 
 permissions:
-  pull-requests: read
+  pull-requests: read  # required by action-semantic-pull-request to read the PR title via the GitHub API
 
 jobs:
   pull-request:

--- a/.github/workflows/_pull-request.yaml
+++ b/.github/workflows/_pull-request.yaml
@@ -12,4 +12,4 @@ permissions:
 
 jobs:
   pull-request:
-    uses: nozomiishii/workflows/.github/workflows/pull-request.yaml@7e6fb98cc189a7b5ef23eee616a04238c5d9a468 # v1.1.1
+    uses: nozomiishii/workflows/.github/workflows/pull-request.yaml@4114f39af968607bdcef88b48d29605df89728fd # v3.0.0

--- a/.github/workflows/_secret-scan.yaml
+++ b/.github/workflows/_secret-scan.yaml
@@ -11,5 +11,5 @@ permissions:
   contents: read
 
 jobs:
-  secretlint:
-    uses: nozomiishii/workflows/.github/workflows/secretlint.yaml@7e6fb98cc189a7b5ef23eee616a04238c5d9a468 # v1.1.1
+  secret-scan:
+    uses: nozomiishii/workflows/.github/workflows/secret-scan.yaml@4114f39af968607bdcef88b48d29605df89728fd # v3.0.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-slim
     timeout-minutes: 10
     permissions:
-      contents: write
-      issues: write
-      pull-requests: write
+      contents: write  # required by release-please-action to create release commits, tags, and GitHub Releases
+      issues: write  # required by release-please-action to label release-related issues
+      pull-requests: write  # required by release-please-action to open and update the release PR
 
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
@@ -59,11 +59,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: write
+      contents: write  # required by gh release upload to attach built binaries to the GitHub Release
 
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
@@ -90,7 +92,8 @@ jobs:
       - name: Upload release assets
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${{ needs.release-please.outputs.tag_name }}" dist/*
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+        run: gh release upload "$TAG_NAME" dist/*
 
   npm-publish:
     needs: release-please
@@ -98,12 +101,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: read
-      id-token: write
+      contents: read  # required by actions/checkout to fetch repository code
+      id-token: write  # required by npm publish for OIDC-based trusted publishing to the npm registry
 
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,14 +20,21 @@ defaults:
   run:
     shell: bash
 
+# デフォルト権限を無効化し、各ジョブで必要最小限の権限のみ付与する
+permissions: {}
+
 jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read  # required by actions/checkout to fetch repository code
 
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Check for changes
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1


### PR DESCRIPTION
## 概要

`nozomiishii/workflows` v3.0.0 リリースに先行して caller 側を移行する。pin は main HEAD の SHA（v3.0.0 release PR merge 直前の状態）を使用。

## 変更内容

- `_actionlint.yaml` → **`_github-actions.yaml`**
  - 呼び先を v2 aggregator `github-actions.yaml`（actionlint + zizmor）に差し替え
  - permissions に `actions: read` 追加（zizmor auditor persona 用）
  - job / workflow 名も v2 に合わせて rename
- `_secretlint.yaml` → **`_secret-scan.yaml`**
  - 呼び先を v2 concept-named `secret-scan.yaml` に差し替え
- `_pull-request.yaml`
  - SHA pin を v3.0.0（未リリース、main HEAD）に bump

## ⚠️ branch protection 更新が必要

この PR を merge する前に、default branch の required status checks を以下に更新:

| 旧 | 新 |
|---|---|
| `actionlint / lint` | `github-actions / required` |
| `secretlint / scan` | `secret-scan / secretlint` |
| `pull-request / validate` | そのまま |

## 関連

- 既存の renovate PR（SHA の単純 bump）は本 PR で代替するので close する
- `nozomiishii/workflows` 側の v3.0.0 release PR は全 caller migration 完了後に merge される予定
