### PR TITLE
chore(workflows): fix zizmor findings in caller workflows

### DIFF
--- a/.github/workflows/_github-actions.yaml
+++ b/.github/workflows/_github-actions.yaml
@@ -12,9 +12,9 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
-  pull-requests: read
-  actions: read
+  contents: read  # required by actions/checkout to fetch repository code
+  pull-requests: read  # required by dorny/paths-filter to list PR files via the GitHub API
+  actions: read  # required by gh api referenced_workflows to resolve the zizmor config SHA
 
 jobs:
   github-actions:

--- a/.github/workflows/_pull-request.yaml
+++ b/.github/workflows/_pull-request.yaml
@@ -8,7 +8,7 @@ on:
       - synchronize
 
 permissions:
-  pull-requests: read
+  pull-requests: read  # required by action-semantic-pull-request to read the PR title via the GitHub API
 
 jobs:
   pull-request:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -92,7 +92,8 @@ jobs:
       - name: Upload release assets
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${{ needs.release-please.outputs.tag_name }}" dist/*
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+        run: gh release upload "$TAG_NAME" dist/*
 
   npm-publish:
     needs: release-please

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-slim
     timeout-minutes: 10
     permissions:
-      contents: write
-      issues: write
-      pull-requests: write
+      contents: write  # required by release-please-action to create release commits, tags, and GitHub Releases
+      issues: write  # required by release-please-action to label release-related issues
+      pull-requests: write  # required by release-please-action to open and update the release PR
 
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
@@ -59,11 +59,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: write
+      contents: write  # required by gh release upload to attach built binaries to the GitHub Release
 
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
@@ -98,12 +100,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: read
-      id-token: write
+      contents: read  # required by actions/checkout to fetch repository code
+      id-token: write  # required by npm publish for OIDC-based trusted publishing to the npm registry
 
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,14 +20,21 @@ defaults:
   run:
     shell: bash
 
+# デフォルト権限を無効化し、各ジョブで必要最小限の権限のみ付与する
+permissions: {}
+
 jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read  # required by actions/checkout to fetch repository code
 
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Check for changes
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1


### PR DESCRIPTION
## Summary

Migration PR (#69) に stacked。zizmor auditor persona の finding を全部解消する。

## Fixes
- `_github-actions.yaml` / `_pull-request.yaml`: permissions に justification コメント（`undocumented-permissions`）
- `test.yaml`: workflow top-level `permissions: {}` + job 最小 permissions + `actions/checkout` に `persist-credentials: false`
- `release.yaml`: `actions/checkout` に `persist-credentials: false` + permissions コメント

## Test plan
- [ ] `github-actions / required` 緑
- [ ] `secret-scan / secretlint` 緑
- [ ] `pull-request / validate` 緑
