### PR TITLE
fix(ci): scope github-actions trigger to pull_request only

### DIFF
--- a/.github/workflows/_github-actions.yaml
+++ b/.github/workflows/_github-actions.yaml
@@ -1,10 +1,6 @@
 name: GitHub Actions
 
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - main
   pull_request:
 
 concurrency:


### PR DESCRIPTION
## Summary

- 共通ワークフロー `nozomiishii/workflows@v3` の `github-actions.yaml` の `changes` ジョブで使っている `dorny/paths-filter` は、`push` イベントでは before SHA との `git diff` を取るため `git fetch` を行うが、共通ワークフロー側の `actions/checkout` を `persist-credentials: false` で動かしているため認証エラー (`exit 128`) になる
- caller (`_github-actions.yaml`) のトリガーから `workflow_dispatch` と `push: branches: [main]` を削除し `pull_request` のみに絞ることで、本来 PR の差分検出を目的とした paths-filter を想定通りのコンテキストでのみ動かす
- main マージ前の PR で必ず lint を通す運用なので、main 直接 push 用のトリガーは不要
- `workflow_dispatch` も合わせて削除する理由: paths-filter は default branch (main) で手動実行する分には `git log -n 1` のみで動くが、main 以外のブランチで手動実行すると merge-base 取得のため `git fetch` を発火し同じ認証エラーになる。ブランチによって壊れ方が変わる挙動は避けたい

## Background

- workflows v3 移行 (PR `chore: migrate reusable workflows to v3.0.0`) 後、main push のたびに `changes` ジョブが exit 128 で必ず失敗していた
- 共通ワークフロー集なので、`_github-actions.yaml` を持つ全リポジトリ (workspaces / homebrew-tap / workflows / dotfiles / infra / configs / dev / nozomiishii / renovate / pm / git-harvest / Brooklyn) で同様の修正 PR を出している
- 元修正 PR: <https://github.com/nozomiishii/workflows/pull/38>

## Test plan

- [ ] PR の作成・更新で `pull_request` トリガーの GitHub Actions が起動して通ること
- [ ] マージ後、main への push では本ワークフローが起動しないことを Actions 一覧で確認
