### PR TITLE
fix(ci): scope test trigger to pull_request only

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,15 +1,6 @@
 name: Test
 
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths:
-      - 'src/**'
-      - 'package.json'
-      - 'tsconfig.json'
-      - 'bun.lock'
   pull_request:
 
 concurrency:


### PR DESCRIPTION
## Summary

- 共通ワークフロー側の `actions/checkout` を `persist-credentials: false` で動かしている状態で、`dorny/paths-filter` が `push` イベントの before SHA との `git diff` のために `git fetch` を呼ぶと認証エラー (`exit 128`) で必ず失敗する
- `test.yaml` のトリガーから `workflow_dispatch` と `push: branches: [main]` を削除し、`pull_request` のみに絞る
- main マージ前の PR で必ず test を通す運用なので、main 直接 push 用のトリガーは不要
- `workflow_dispatch` も合わせて削除する理由: paths-filter は default branch (main) で手動実行する分には `git log -n 1` のみで動くが、main 以外のブランチで手動実行すると merge-base 取得のため `git fetch` を発火し同じ認証エラーになる。ブランチによって壊れ方が変わる挙動は避けたい

## Background

- workflows v3 移行後、`_github-actions.yaml` 系の同じ問題は別 PR で修正済み (`fix(ci): scope github-actions trigger to pull_request only`)
- 本 PR は同じ paths-filter + persist-credentials: false の組み合わせを持つ `test.yaml` への姉妹修正
- 元修正 PR: <https://github.com/nozomiishii/workflows/pull/38>、<https://github.com/nozomiishii/infra/pull/14>

## Test plan

- [ ] PR の作成・更新で `pull_request` トリガーの `Test` workflow が起動して通ること
- [ ] マージ後、main への push では本ワークフローが起動しないことを Actions 一覧で確認
