### PR TITLE
chore: trim redundant command sections from claude.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,30 +2,6 @@
 
 このリポジトリで Claude Code (claude.ai/code) が作業する際のガイドラインです。
 
-## よく使うコマンド
-
-```bash
-# 依存のインストール
-bun install
-
-# テスト実行
-bun run test
-
-# ネイティブバイナリをビルド
-bun run build
-
-# npm パッケージ用のビルドは prepublishOnly に記述する (npm publish 時に自動実行される)
-
-# デモ GIF を生成 (Docker 経由)
-bun run demo:all
-
-# 個別のデモを生成
-bun demo demo/logo.tape
-
-# ローカルで CLI を実行
-bun dev logo
-```
-
 ## アーキテクチャ概要
 
 [VS Code Project Manager](https://marketplace.visualstudio.com/items?itemName=alefragnani.project-manager) の `projects.json` をターミナルから操作する CLI ツール。Bun でネイティブバイナリにコンパイルし、`install.sh` で配布する。


### PR DESCRIPTION
## Summary

`CLAUDE.md` から package.json / Makefile を読めば自明な「よく使うコマンド」セクションを削除し、ドキュメントの冗長性を低減する。

## 動機

`package.json` scripts や `Makefile` に書かれている内容を `CLAUDE.md` に重複して保持すると、片方の更新時にもう一方が drift し、AI / 人間ともに「コマンドの正本がどこか」が曖昧になる。正本を一本化するため、`CLAUDE.md` 側からはそれらを削除する。

## Test plan

- [ ] `CLAUDE.md` のレンダリングが崩れていない
- [ ] 残されたセクションの内容に変更が無い
