### PR TITLE
chore: migrate create-github-app-token input from app-id to client-id

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ steps.secrets.outputs.APP_ID }}
+          client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
 
       - name: Run release-please


### PR DESCRIPTION
## 背景

`actions/create-github-app-token@v3` で `app-id:` 入力が deprecated になり、release ワークフローの実行時に毎回 warning が出る:

```
Input 'app-id' has been deprecated with message: Use 'client-id' instead.
```

## 修正内容

`app-id:` を `client-id:` にリネーム。action 内部では両方とも `createAppAuth({ appId: ... })` に同じ値で渡されるだけなので、1Password の secret 値も `APP_ID` の env マッピングもそのまま流用できる（参考: [actions/create-github-app-token の action.yml](https://github.com/actions/create-github-app-token/blob/main/action.yml) と `lib/main.js`）。

## Test plan

- [ ] release ワークフローで deprecation warning が出ない
- [ ] `Generate GitHub App token` ステップが正常にトークンを発行する
