### PR TITLE
feat: show README preview in fzf picker

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -79,17 +79,26 @@ function plainLabel(name: string): string {
 
 function fzfSelect(projects: Project[]): Promise<Project | undefined> {
   return new Promise((resolve, reject) => {
-    const labels = projects.map((p) => plainLabel(p.name));
-    const proc = spawn("fzf", [], {
-      stdio: ["pipe", "pipe", "inherit"],
-    });
+    const lines = projects.map((p) => `${plainLabel(p.name)}\t${expandHome(p.rootPath)}`);
+    const proc = spawn(
+      "fzf",
+      [
+        "--delimiter=\t",
+        "--with-nth=1",
+        "--preview",
+        "bat --color=always --style=header,grid --line-range :80 {2}/README.* 2>/dev/null || echo 'No README found'",
+      ],
+      {
+        stdio: ["pipe", "pipe", "inherit"],
+      },
+    );
 
     let stdout = "";
     proc.stdout.on("data", (d: Buffer) => {
       stdout += d.toString();
     });
 
-    proc.stdin.write(labels.join("\n") + "\n");
+    proc.stdin.write(lines.join("\n") + "\n");
     proc.stdin.end();
 
     proc.on("close", (code) => {
@@ -98,7 +107,7 @@ function fzfSelect(projects: Project[]): Promise<Project | undefined> {
         return;
       }
       const selected = stdout.trim();
-      const idx = labels.indexOf(selected);
+      const idx = lines.indexOf(selected);
       resolve(idx >= 0 ? projects[idx] : undefined);
     });
 


### PR DESCRIPTION
## 概要

`pm` の fzf ピッカーに README プレビューを追加します。プロジェクトを選ぶ前に各リポジトリの README を確認できるので、用途を思い出しやすくなります。

## 変更点

- `fzfSelect` で各行を `label\trootPath` の tab 区切りで fzf に渡す
- `--delimiter='\t' --with-nth=1` で表示はラベルのみに保ち、preview では `{2}` (rootPath) を参照
- preview コマンド: `bat --color=always --style=header,grid --line-range :80 {2}/README.* 2>/dev/null || echo 'No README found'`
  - bat 未インストール / README 不在の場合は `echo 'No README found'` にフォールバック
  - `README.md` と `README.ja.md` が両方ある場合は連続表示

## 動作確認

- `bun run typecheck` 通過
- `bun run dev` で fzf を起動し、右側 preview に README が表示されることを確認

## 参考

ghq + fzf でよくある preview パターンを踏襲:

```sh
fzf --preview "bat --color=always --style=header,grid --line-range :80 $(ghq root)/{}/README.*"
```
