### PR TITLE
chore: add ghostty keybind tip to readme

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -157,6 +157,20 @@ pm() {
 
 この仕組みにより、プロジェクト名のタブ補完もサポートしています。
 
+## Tips
+
+### Ghostty のキーバインドで一発起動
+
+[Ghostty](https://ghostty.org) を使っている場合、設定ファイルに次の行を追加するとキーバインド一発で `pm` を起動できます。
+
+```
+keybind = super+alt+j=text:pm\n
+```
+
+`super+alt+j` を押すと現在のターミナルへ `pm` + Enter が送信され、fzf ピッカーが即座に開きます。
+
+設定ファイルのパスは OS によって異なるので、[Ghostty 公式ドキュメントの Configuration](https://ghostty.org/docs/config) を参照してください。
+
 ## 謝辞
 
 pm は以下のプロジェクトから大きな影響を受けています。僕の生産性を上げてくれて本当にありがとうございます

--- a/README.md
+++ b/README.md
@@ -157,6 +157,20 @@ pm() {
 
 This mechanism also provides tab completion for project names.
 
+## Tips
+
+### Launch with a Ghostty keybind
+
+If you use [Ghostty](https://ghostty.org), add the following line to your config to launch `pm` with a single keybind.
+
+```
+keybind = super+alt+j=text:pm\n
+```
+
+Pressing `super+alt+j` sends `pm` + Enter to the current terminal, instantly opening the fzf picker.
+
+The config file path differs by OS, so see the [Configuration page in the Ghostty docs](https://ghostty.org/docs/config) for the exact location.
+
 ## Acknowledgments
 
 pm is heavily inspired by these projects. Thank you so much for boosting my productivity.


### PR DESCRIPTION
## 概要

Ghostty ユーザー向けに、キーバインド一発で `pm` を起動するためのスニペットを README に追記する。

## 変更内容

- README.md / README.ja.md の Configuration の直後に `## Tips` セクションを新設
- `keybind = super+alt+j=text:pm\n` の例と挙動を記載
- 設定ファイルのパスは OS によって異なるため、[Ghostty 公式ドキュメントの Configuration ページ](https://ghostty.org/docs/config) へのリンクで案内

## 動機

`pm` 自体が「ターミナル上で素早くプロジェクトに飛ぶ」CLI なので、ターミナルの起動・呼び出し自体も最短化できると体験がさらに良くなる。Ghostty を使っているユーザーには `keybind = ...text:pm\n` のワンライナーが特に効くので、Tips としてまとめた。
