### PR TITLE
chore: add startup hook for session sync

### DIFF
--- a/.claude/hooks/startup.sh
+++ b/.claude/hooks/startup.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# セッション開始時に worktree を整える（可能なら origin/main 取り込み、必要なら deps install）。
+
+git fetch origin --quiet
+
+# 既存の commit や未保存変更を壊さない範囲で HEAD を origin/main まで進める。
+# 取り込み時に lock 更新があれば post-merge hook が bun install を実行する。
+if git merge-base --is-ancestor HEAD origin/main 2>/dev/null; then
+  # merge commit を作らず HEAD を進めるだけ → linear history を維持
+  git merge --ff-only origin/main --quiet
+fi
+
+if [ ! -d node_modules ]; then
+  # fresh worktree 初回など
+  bun install
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,6 +8,15 @@
             "command": "bun install"
           }
         ]
+      },
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/startup.sh\""
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
## Summary
- `.claude/hooks/startup.sh` を新規追加（session 開始時の origin/main 同期 + 必要なら bun install）
- `.claude/settings.json` の SessionStart hook に上記スクリプトを呼ぶ entry を追加

## 背景
[nozomiishii/workspaces#34](https://github.com/nozomiishii/workspaces/issues/34) のロールアウト作業の一環。

スクリプトは dotfiles の確立済みパターンに従う:
- `--ff-only` で linear history を維持
- HEAD が origin/main の祖先のときだけ進める（既存作業を壊さない）
- `set -euo pipefail` で strict mode

post-merge hook が lock 更新時の install をカバーし、node_modules 不在時はスクリプト末尾の install がフォールバック。

## Test plan
- [x] `bash -n .claude/hooks/startup.sh`（syntax check）
- [x] `bash .claude/hooks/startup.sh` を clean な状態で実行 → exit 0
- [x] `jq '.' .claude/settings.json`（JSON valid）

refs nozomiishii/workspaces#34
