### PR TITLE
fix: scope release app token permissions and pin op cli version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,6 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: write  # required by release-please-action to create release commits, tags, and GitHub Releases
-      issues: write  # required by release-please-action to label release-related issues
       pull-requests: write  # required by release-please-action to open and update the release PR
 
     outputs:
@@ -33,6 +32,9 @@ jobs:
       - name: Load secrets from 1Password
         id: secrets
         uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4
+        with:
+          # renovate: datasource=docker depName=1password/op versioning=semver
+          version: "2.34.0"
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           APP_ID: op://github-app/nozomiishii-release/username
@@ -44,6 +46,8 @@ jobs:
         with:
           client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Run release-please
         id: release


### PR DESCRIPTION
## 概要

zizmor v1.25.0 で新たに CI を落とす 2 つの audit を先回りで正攻法に解消する。

- **github-app (high)**: `actions/create-github-app-token` が blanket な権限でトークンを発行していた指摘。`permission-contents: write` / `permission-pull-requests: write` を明示し、release-please に必要な最小権限へ絞る。
- **unpinned-tools (medium)**: `1password/load-secrets-action` が op CLI の version 未指定だった指摘。`version: "2.34.0"` を pin（renovate アノテーション付き）。

## issues 権限を付けない理由

`release-please` job の `permissions` から `issues: write` を削除した。`issues` 権限は GitHub App (`nozomiishii-release`) に付与されておらず、付けると release が 422 で失敗する。release-please は本 repo では issue を作らないため不要。

## 検証

`zizmor --persona=auditor` で release.yaml を監査し、findings 0 を確認済み。
