### PR TITLE
fix: grant workflows permission to release app token for non-head releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: write  # required by release-please-action to create release commits, tags, and GitHub Releases
+      issues: write  # kept to match release-please's documented permission set (avoids divergence-debugging later)
       pull-requests: write  # required by release-please-action to open and update the release PR
 
     outputs:
@@ -47,7 +48,13 @@ jobs:
           client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
           permission-contents: write
+          permission-issues: write  # kept to match release-please's documented permission set (avoids divergence-debugging later)
           permission-pull-requests: write
+          # GitHub requires workflows:write to create a release/tag on a commit that is
+          # not the current branch head. release-please tags the (already-merged, now
+          # non-head) release commit, so without this the create-release call returns
+          # 403 "Resource not accessible by integration".
+          permission-workflows: write
 
       - name: Run release-please
         id: release


### PR DESCRIPTION
## 概要

release を作成する app token に `permission-workflows: write`（+ パリティで `permission-issues: write`）を追加する。

## 背景

GitHub の仕様で、ブランチ先端(HEAD)でないコミットへ release/tag を作るには `workflows: write` が必要（`contents:write` だけだと先端コミットにしか作れず `403 Resource not accessible by integration` になる）。release-please は release PR のマージコミット（固定 SHA）を tag するため、release 実行前に別の push が main に入って tip が動くとその commit が非先端になり release 作成に失敗する。Renovate でマージ頻度が高いと踏みうる。

- 参考: https://github.blog/changelog/2023-11-02-github-actions-enforcing-workflow-scope-when-creating-a-release/ / https://github.com/cli/cli/issues/9514
- nozomiishii/configs で実証・修正済み（#2308）。本 PR は横展開。

## 変更

- release-please ジョブの app token に `permission-issues: write` と `permission-workflows: write` を追加
- 同ジョブ job 直下 permissions に `issues: write` を追加（release-please 公式の権限セットに合わせる）
- release を作成しない他ジョブ/ステップは変更なし
