### PR TITLE
fix: checkout released tag in publish jobs to avoid stale republish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,6 +76,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          # Pin to the released tag, not the run's trigger commit. When PRs merge in
+          # rapid succession, the run that creates the release can be one whose checkout
+          # SHA predates the version bump, so this job would build/publish a stale
+          # version (e.g. npm "cannot publish over the previously published versions").
+          ref: ${{ needs.release-please.outputs.tag_name }}
           persist-credentials: false
 
       - name: Setup Bun
@@ -119,6 +124,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          # Pin to the released tag, not the run's trigger commit. When PRs merge in
+          # rapid succession, the run that creates the release can be one whose checkout
+          # SHA predates the version bump, so this job would build/publish a stale
+          # version (e.g. npm "cannot publish over the previously published versions").
+          ref: ${{ needs.release-please.outputs.tag_name }}
           persist-credentials: false
 
       - name: Setup Node.js

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,10 +76,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          # Pin to the released tag, not the run's trigger commit. When PRs merge in
-          # rapid succession, the run that creates the release can be one whose checkout
-          # SHA predates the version bump, so this job would build/publish a stale
-          # version (e.g. npm "cannot publish over the previously published versions").
+          # Pin to the released tag, not the run's trigger commit: with rapid merges the
+          # release-creating run may predate the version bump and publish a stale version.
           ref: ${{ needs.release-please.outputs.tag_name }}
           persist-credentials: false
 
@@ -124,10 +122,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          # Pin to the released tag, not the run's trigger commit. When PRs merge in
-          # rapid succession, the run that creates the release can be one whose checkout
-          # SHA predates the version bump, so this job would build/publish a stale
-          # version (e.g. npm "cannot publish over the previously published versions").
+          # Pin to the released tag, not the run's trigger commit: with rapid merges the
+          # release-creating run may predate the version bump and publish a stale version.
           ref: ${{ needs.release-please.outputs.tag_name }}
           persist-credentials: false
 


### PR DESCRIPTION
## 概要

release の `build-and-release` / `npm-publish` ジョブが run の trigger commit ではなく **release されたタグ**をチェックアウトするよう修正する。

## 背景

短い間隔で PR を連続マージすると、release を作成する run が「version bump コミットより前の commit を起動 SHA に持つ run」になることがある（実例: [run 26218100737](https://github.com/nozomiishii/pm/actions/runs/26218100737)）。release-please は main を API 経由で見て release を作るため `release_created=true` になるが、後続の publish/build ジョブは `ref:` 未指定で **起動 SHA（= bump 前のコミット）** をチェックアウトしてしまう。結果、古いバージョンを publish しようとして以下で落ちる:

```
npm error You cannot publish over the previously published versions: 0.2.1.
```

このとき v0.2.2 の GitHub Release は作成済みなのに npm は未 publish、という食い違いが残った。

## 変更

`build-and-release` / `npm-publish` の `actions/checkout` に `ref: ${{ needs.release-please.outputs.tag_name }}` を追加。release-please が出力する tag を起点にすることで、どの run が release を作成しても必ず「release されたバージョンのコミット」を build / publish する。`tag_name` output は既存。

## 補足

既に発生している v0.2.2 の npm 未 publish 分は、本修正とは別に手動で解消する。